### PR TITLE
feat(file-browser-upload):  `file-browser-urls` support multi urls, will auto switch host fast (1.7.+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Please read [Contributor Guide](.github/CONTRIBUTING_DOC/CONTRIBUTING.md) for mo
 - [x] support send result to woodpecker steps transfer
 - [x] docker platform support (v1.6.+)
   -  `linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/ppc64le linux/s390x`
+- [x] support link choose by web test
+  - [x] `file-browser-urls` support multi urls, will auto switch host fast (1.7.+)
 
 ## usage
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -14,16 +14,16 @@ woodpecker-file-browser-upload
 ## Features
 
 - [x] upload file to file browser
-  - [x] support file with [glob](https://pkg.go.dev/path/filepath#Match)
-  - [x] support file with regular expression
+    - [x] support file with [glob](https://pkg.go.dev/path/filepath#Match)
+    - [x] support file with regular expression
 - [x] set file custom dist graph
 - [x] support share link
-  - [x] support share link expires
-  - [x] support share link auto password
-  - [x] support share link password
+    - [x] support share link expires
+    - [x] support share link auto password
+    - [x] support share link password
 - [x] support send result to woodpecker steps transfer
 - [x] docker platform support (v1.6.+)
-  -  `linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/ppc64le linux/s390x`
+    - `linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/ppc64le linux/s390x`
 
 ## Settings
 
@@ -32,6 +32,7 @@ woodpecker-file-browser-upload
 | `debug`                                   | **no**   | *false*       | open debug log or open by env `PLUGIN_DEBUG`                                                                 |
 | `file-browser-timeout-send-second`        | **no**   | *60*          | push each file timeout push second, must gather than 60.default: 60                                          |
 | `file-browser-host`                       | **yes**  | *none*        | file_browser host like http://127.0.0.1:80                                                                   |
+| `file-browser-urls`                       | **no**   |               | file browser urls, support multi urls, will auto switch url fast (1.7.+)                                     |
 | `file-browser-username`                   | **yes**  | *none*        | file_browser username                                                                                        |
 | `file-browser-user-password`              | **yes**  | *none*        | file_browser user password                                                                                   |
 | `file-browser-work-space`                 | **no**   | *none*        | file_browser work space. default "" will use env:CI_WORKSPACE                                                |
@@ -73,6 +74,10 @@ steps:
     settings:
       # debug: false # plugin debug switch
       file-browser-host: "http://127.0.0.1:80" # must set args, file_browser host like http://127.0.0.1:80
+      file-browser-urls: # support multi urls, will auto switch url fast (1.7.+)
+        - https://filebrowser-inner.example.com
+        - https://filebrowser.example.com
+        - https://filebrowser-zone.example.com
       file-browser-username: # must set args, file_browser username
         # https://woodpecker-ci.org/docs/usage/secrets
         from_secret: file_browser_user_name
@@ -101,10 +106,10 @@ steps:
 go install -a github.com/woodpecker-kit/woodpecker-file-browser-upload/cmd/woodpecker-file-browser-upload@latest
 ```
 
-- install at ${GOPATH}/bin, v1.0.0
+- install at ${GOPATH}/bin, v1.7.0
 
 ```bash
-go install -v github.com/woodpecker-kit/woodpecker-file-browser-upload/cmd/woodpecker-file-browser-upload@v1.0.0
+go install -v github.com/woodpecker-kit/woodpecker-file-browser-upload/cmd/woodpecker-file-browser-upload@v1.7.0
 ```
 
 ```yml
@@ -116,6 +121,10 @@ steps:
     settings:
       # debug: false # plugin debug switch
       file-browser-host: "http://127.0.0.1:80" # must set args, file_browser host like http://127.0.0.1:80
+      file-browser-urls: # support multi urls, will auto switch url fast (1.7.+)
+        - https://filebrowser-inner.example.com
+        - https://filebrowser.example.com
+        - https://filebrowser-zone.example.com
       file-browser-username: # must set args, file_browser username
         # https://woodpecker-ci.org/docs/usage/secrets
         from_secret: file_browser_user_name
@@ -143,8 +152,12 @@ steps:
     pull: false
     settings:
       debug: false # plugin debug switch
-      timeout_second: 10 # api timeout default: 10
-      file-browser-timeout-send-second: 60 # push each file timeout push second, must gather than 60.default: 60
+      timeout_second: 10 # api timeout, minimum 10 .default: 10
+      file-browser-timeout-send-second: 60 # push each file timeout push second, minimum 60 .default: 60
+      file-browser-urls: # support multi urls, will auto switch url fast (1.7.+)
+        - https://filebrowser-inner.example.com
+        - https://filebrowser.example.com
+        - https://filebrowser-zone.example.com
       file-browser-host: # must set args, file_browser base url, like http://127.0.0.1:80
         # https://woodpecker-ci.org/docs/usage/secrets
         from_secret: file_browser_host_url

--- a/file_browser_upload/flag.go
+++ b/file_browser_upload/flag.go
@@ -16,6 +16,9 @@ const (
 	CliNameFileBrowserHost = "settings.file-browser-host"
 	EnvFileBrowserHost     = "PLUGIN_FILE_BROWSER_HOST"
 
+	CliNameFileBrowserUrls = "settings.file-browser-urls"
+	EnvFileBrowserUrls     = "PLUGIN_FILE_BROWSER_URLS"
+
 	CliNameFileBrowserUsername = "settings.file-browser-username"
 	EnvFileBrowserUsername     = "PLUGIN_FILE_BROWSER_USERNAME"
 
@@ -68,6 +71,12 @@ func GlobalFlag() []cli.Flag {
 			Usage:   "file browser host",
 			EnvVars: []string{EnvFileBrowserHost},
 		},
+		&cli.StringSliceFlag{
+			Name:    CliNameFileBrowserUrls,
+			Usage:   fmt.Sprintf("set file browser support multi urls, will auto switch host fast, if not set or host not work, will use standby url, this will cover %s", CliNameFileBrowserHost),
+			EnvVars: []string{EnvFileBrowserUrls},
+		},
+
 		&cli.StringFlag{
 			Name:    CliNameFileBrowserUsername,
 			Usage:   "file browser username",
@@ -172,6 +181,7 @@ func BindCliFlags(c *cli.Context,
 
 		FileBrowserBaseConfig: FileBrowserBaseConfig{
 			FileBrowserHost:              c.String(CliNameFileBrowserHost),
+			FileBrowserUrls:              c.StringSlice(CliNameFileBrowserUrls),
 			FileBrowserUsername:          c.String(CliNameFileBrowserUsername),
 			FileBrowserUserPassword:      c.String(CliNameFileBrowserUserPassword),
 			FileBrowserTimeoutPushSecond: c.Uint(CliNameFileBrowserTimeOutSendSecond),

--- a/file_browser_upload/http_link_speed.go
+++ b/file_browser_upload/http_link_speed.go
@@ -1,0 +1,49 @@
+package file_browser_upload
+
+import "time"
+
+const (
+	minimumTimeoutSecond = 3
+	minimumRetries       = 3
+	defaultConcurrency   = 10
+)
+
+type HttpLinkSpeedResult struct {
+	URL              string
+	BestResponseTime time.Duration
+	Error            error
+	RetryCount       int // record retries
+}
+
+type HttpLinkSpeed struct {
+	HttpLinkSpeedFunc HttpLinkSpeedFunc `json:"-"`
+
+	concurrency   uint
+	timeoutSecond uint
+	maxRetries    uint
+}
+
+type HttpLinkSpeedFunc interface {
+	SetConcurrency(concurrency uint)
+
+	BestLinkIgnoreRetry(urls []string) (string, error)
+
+	DoUrls(urls []string) ([]HttpLinkSpeedResult, error)
+}
+
+// NewLinkSpeed create a new link speed
+// timeoutSecond: timeout for each request in second (minimum 5s)
+// maxRetries: maxRetries for each request (minimum 3)
+func NewLinkSpeed(timeoutSecond, retries uint) *HttpLinkSpeed {
+	if timeoutSecond < minimumTimeoutSecond {
+		timeoutSecond = minimumTimeoutSecond
+	}
+	if retries < minimumRetries {
+		retries = minimumRetries
+	}
+	return &HttpLinkSpeed{
+		concurrency:   defaultConcurrency,
+		timeoutSecond: timeoutSecond,
+		maxRetries:    retries,
+	}
+}

--- a/file_browser_upload/http_link_speed_impl.go
+++ b/file_browser_upload/http_link_speed_impl.go
@@ -1,0 +1,118 @@
+package file_browser_upload
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// SetConcurrency set concurrency for link speed
+// minimum concurrency is defaultConcurrency = 10
+func (l *HttpLinkSpeed) SetConcurrency(concurrency uint) {
+	if concurrency > defaultConcurrency {
+		l.concurrency = concurrency
+	}
+}
+
+func (l *HttpLinkSpeed) BestLinkIgnoreRetry(urls []string) (string, error) {
+	if len(urls) == 0 {
+		return "", fmt.Errorf("urls is empty")
+	}
+
+	results, errDoUrls := l.DoUrls(urls)
+	if errDoUrls != nil {
+		return "", errDoUrls
+	}
+
+	bestURL := ""
+	bestResponseTime := time.Duration(0)
+	for _, result := range results {
+		if result.BestResponseTime == 0 {
+			continue
+		}
+		if bestResponseTime == 0 || result.BestResponseTime < bestResponseTime {
+			bestResponseTime = result.BestResponseTime
+			bestURL = result.URL
+		}
+	}
+
+	if bestURL == "" {
+		return "", fmt.Errorf("not found best url")
+	}
+
+	return bestURL, nil
+}
+
+func (l *HttpLinkSpeed) DoUrls(urls []string) ([]HttpLinkSpeedResult, error) {
+	if len(urls) == 0 {
+		return nil, fmt.Errorf("urls is empty")
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan HttpLinkSpeedResult, len(urls))
+
+	for _, url := range urls {
+		wg.Add(1)
+		go func(u string) {
+			defer wg.Done()
+
+			var result HttpLinkSpeedResult
+			var ctx context.Context
+			var cancel context.CancelFunc
+
+			maxRetry := int(l.maxRetries)
+			timeoutSecond := time.Duration(l.timeoutSecond) * time.Second
+			bestResponseTime := time.Duration(0)
+
+			for retries := 0; retries <= maxRetry; retries++ {
+				result.URL = u
+
+				ctx, cancel = context.WithTimeout(context.Background(), timeoutSecond)
+				req, errNewRequest := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+				if errNewRequest != nil {
+					result.Error = errNewRequest
+					result.RetryCount = result.RetryCount + 1
+					cancel() // 取消当前请求的上下文，释放资源
+					continue
+				}
+
+				req.Header.Add("Cache-Control", "no-cache")
+				start := time.Now()
+				resp, errDoRequest := http.DefaultClient.Do(req)
+				if errDoRequest != nil {
+					result.Error = errDoRequest
+					result.RetryCount = result.RetryCount + 1
+					cancel() // 取消当前请求的上下文，释放资源
+					continue
+				}
+				defer resp.Body.Close()
+
+				durationTIme := time.Since(start)
+
+				if bestResponseTime == 0 || durationTIme < bestResponseTime {
+					bestResponseTime = durationTIme
+				}
+
+				result.BestResponseTime = bestResponseTime
+				result.Error = nil
+				cancel() // 取消当前请求的上下文，释放资源
+			}
+
+			results <- result
+		}(url)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var allResults []HttpLinkSpeedResult
+	for result := range results {
+		allResults = append(allResults, result)
+	}
+
+	return allResults, nil
+}

--- a/file_browser_upload/settings.go
+++ b/file_browser_upload/settings.go
@@ -1,6 +1,11 @@
 package file_browser_upload
 
 const (
+	TimeoutSecondMinimum       = 10
+	UploadTimeoutSecondMinimum = 60
+	TryConnectTimeoutSecond    = 5
+	TryConnectRetries          = 3
+
 	DistTypeGit    = "git"
 	DistTypeCustom = "custom"
 
@@ -45,11 +50,18 @@ type (
 	}
 
 	FileBrowserBaseConfig struct {
-		FileBrowserHost              string
-		FileBrowserUsername          string
-		FileBrowserUserPassword      string
+		FileBrowserHost         string
+		FileBrowserUsername     string
+		FileBrowserUserPassword string
+
+		FileBrowserUrls []string
+
 		FileBrowserTimeoutPushSecond uint
 		FileBrowserWorkSpace         string
+
+		usedFileBrowserUrl          string
+		usedFileBrowserUsername     string
+		usedFileBrowserUserPassword string
 	}
 
 	FileBrowserSendConfig struct {

--- a/file_browser_upload_test/http_link_speed_test.go
+++ b/file_browser_upload_test/http_link_speed_test.go
@@ -1,0 +1,121 @@
+package file_browser_upload_test
+
+import (
+	"github.com/sinlov-go/unittest-kit/env_kit"
+	"github.com/stretchr/testify/assert"
+	"github.com/woodpecker-kit/woodpecker-file-browser-upload/file_browser_upload"
+	"testing"
+)
+
+func TestHttpHttpBestLinkIgnoreRetry(t *testing.T) {
+
+	testUrls := env_kit.FetchOsEnvStringSlice(keyLinkSpeedTestUrls)
+	if len(testUrls) == 0 {
+		t.Logf("skip test by not set env: %s", keyLinkSpeedTestUrls)
+		return
+	}
+
+	// mock HttpBestLinkIgnoreRetry
+	type args struct {
+		testUrls      []string
+		timeoutSecond uint
+		retries       uint
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "sample",
+			args: args{
+				testUrls:      testUrls,
+				timeoutSecond: 5,
+				retries:       3,
+			},
+		},
+		{
+			name: "with-error-link",
+			args: args{
+				testUrls:      append(testUrls, "http://192.168.30.20"),
+				timeoutSecond: 5,
+				retries:       3,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			linkSpeed := file_browser_upload.NewLinkSpeed(tc.args.timeoutSecond, tc.args.retries)
+
+			// do HttpBestLinkIgnoreRetry
+			gotResult, gotErr := linkSpeed.BestLinkIgnoreRetry(tc.args.testUrls)
+
+			// verify HttpBestLinkIgnoreRetry
+			assert.Equal(t, tc.wantErr, gotErr)
+			if tc.wantErr != nil {
+				return
+			}
+			t.Logf("gotResult: %v", gotResult)
+		})
+	}
+}
+
+func TestHttpLinkSpeed(t *testing.T) {
+
+	testUrls := env_kit.FetchOsEnvStringSlice(keyLinkSpeedTestUrls)
+	if len(testUrls) == 0 {
+		t.Logf("skip test by not set env: %s", keyLinkSpeedTestUrls)
+		return
+	}
+
+	// mock HttpLinkSpeed
+	type args struct {
+		//
+		testUrls      []string
+		timeoutSecond uint
+		retries       uint
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "sample",
+			args: args{
+				testUrls:      testUrls,
+				timeoutSecond: 5,
+				retries:       3,
+			},
+		},
+		{
+			name: "error-link",
+			args: args{
+				testUrls: []string{
+					"http://192.168.30.200",
+					"http://127.0.0.1:50001",
+					"http://127.0.0.1:60001",
+				},
+				timeoutSecond: 5,
+				retries:       3,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// do HttpLinkSpeed
+			linkSpeed := file_browser_upload.NewLinkSpeed(tc.args.timeoutSecond, tc.args.retries)
+			gotResult, gotErr := linkSpeed.DoUrls(tc.args.testUrls)
+
+			// verify HttpLinkSpeed
+			assert.Equal(t, tc.wantErr, gotErr)
+			if tc.wantErr != nil {
+				return
+			}
+			//wd_log.VerboseJsonf(gotResult, "gotResult")
+			t.Logf("gotResult: %v", gotResult)
+		})
+	}
+}

--- a/file_browser_upload_test/init_test.go
+++ b/file_browser_upload_test/init_test.go
@@ -22,6 +22,8 @@ const (
 	keyEnvCiKey  = "CI_KEY"
 	keyEnvCiKeys = "CI_KEYS"
 
+	keyLinkSpeedTestUrls = "ENV_LINK_SPEED_TEST_URLS"
+
 	mockVersion = "v1.0.0"
 	mockName    = "woodpecker-file-browser-upload"
 


### PR DESCRIPTION
feat #18

- Add support for multiple file browser URLs in plugin settings
- Implement automatic switching between URLs for faster connection
- Update README and docs with new feature information
- Add new unit tests for HTTP link speed functionality